### PR TITLE
Fix path separator for Windows

### DIFF
--- a/src/main/resources/sbtjasmine.js
+++ b/src/main/resources/sbtjasmine.js
@@ -69,7 +69,7 @@ EnvJasmine.resourceLoadFactory = function(scope) {
 EnvJasmine.loadGlobal = EnvJasmine.loadFactory(EnvJasmine.topLevelScope);
 EnvJasmine.loadLibGlobal = EnvJasmine.resourceLoadFactory(EnvJasmine.topLevelScope);
 
-EnvJasmine.environment = 'UNIX';
+EnvJasmine.environment = java.lang.System.getProperty("os.name").indexOf('Windows') > -1 ?  'WIN' : 'UNIX';
 
 function setupDirs(appJsRoot, appJsLibRoot, testRoot, confFile) {
 
@@ -172,10 +172,18 @@ function runTests(appJsRoot, appJsLibRoot, testRoot, confFile, envHtml) {
             // TODO: allow 'inline' loading when AMD disabled
             // fileIn = new FileReader(EnvJasmine.specFile);
             // EnvJasmine.cx.evaluateReader(EnvJasmine.currentScope, fileIn, EnvJasmine.specs[i], 0, null);
-            var specLoader = 'require(["' + EnvJasmine.specFile + '"]);';
+            var specPathOsSpecific = "" + EnvJasmine.specFile; // make sure it's a javascript string object rather than a java object
+            if(EnvJasmine.environment == 'WIN') {
+                specPathOsSpecific = specPathOsSpecific.replace(/\\/g, "\\\\");
+            }
+            var specLoader = 'require(["' + specPathOsSpecific + '"]);';
             EnvJasmine.cx.evaluateString(EnvJasmine.currentScope, specLoader, 'Loading '+EnvJasmine.specFile, 0, null);
             print("running the jasmine tests");
-            var windowLoader = 'window.location.assign(["file://", "'+envHtml+'"].join(EnvJasmine.SEPARATOR));';
+            var envHtmlOsSpecific = '' + envHtml; // make sure it's a javascript string object rather than a java object
+            if(EnvJasmine.environment == 'WIN') {
+                envHtmlOsSpecific = '/' + envHtmlOsSpecific.replace(/\\/g, "\\\\");
+            }
+            var windowLoader = 'window.location.assign("file://' + envHtmlOsSpecific + '")';
             EnvJasmine.cx.evaluateString(EnvJasmine.currentScope, windowLoader, 'Executing '+EnvJasmine.specs[i], 0, null);
         } catch (e) {
             print('error running jasmine test: ' + EnvJasmine.specs[i] + "\n error was: " + e );

--- a/src/main/scala/com/gu/SbtJasminePlugin.scala
+++ b/src/main/scala/com/gu/SbtJasminePlugin.scala
@@ -64,6 +64,8 @@ object SbtJasminePlugin extends Plugin {
     outputBundledResource("jasmine/jasmine-html.js", outDir / "jasmine-html.js")
     outputBundledResource("jasmine/jasmine.css", outDir / "jasmine.css")
 
+    val isWin = java.lang.System.getProperty("os.name").indexOf("Windows") > -1;
+
     for {
       testRoot <- testJsRoots
       appJsRoot <- appJsRoots
@@ -71,19 +73,32 @@ object SbtJasminePlugin extends Plugin {
       requireJs <- requireJss
       requireConf <- requireConfs
     } {
-      val runnerString = loadRunnerTemplate.format(
-        testRoot.getAbsolutePath,
-        appJsRoot.getAbsolutePath,
-        appJsLibRoot.getAbsolutePath,
-        requireJs.getAbsolutePath,
-        requireConf.getAbsolutePath,
-        generateSpecRequires(testRoot)
-      )
+      var runnerString = "";
+
+      if(isWin) {
+        runnerString = loadRunnerTemplate.format(
+          "file:///" + testRoot.getAbsolutePath.replaceAll("\\\\", "\\\\\\\\"),
+          "file:///" + appJsRoot.getAbsolutePath.replaceAll("\\\\", "\\\\\\\\"),
+          "file:///" + appJsLibRoot.getAbsolutePath.replaceAll("\\\\", "\\\\\\\\"),
+          "file:///" + requireJs.getAbsolutePath.replaceAll("\\\\", "\\\\\\\\"),
+          "file:///" + requireConf.getAbsolutePath.replaceAll("\\\\", "\\\\\\\\"),
+          generateSpecRequires(testRoot)
+        )
+      } else{
+        runnerString = loadRunnerTemplate.format(
+          testRoot.getAbsolutePath,
+          appJsRoot.getAbsolutePath,
+          appJsLibRoot.getAbsolutePath,
+          requireJs.getAbsolutePath,
+          requireConf.getAbsolutePath,
+          generateSpecRequires(testRoot)
+        )
+      }
 
       IO.write(outDir / "runner.html", runnerString)
 
     }
-    s.log.info("output to: file://" + (outDir / "runner.html" getAbsolutePath) )
+    s.log.info("output to: file://" + (if(isWin) "/" else "") + (outDir / "runner.html" getAbsolutePath) )
 
   }
 


### PR DESCRIPTION
This patch fixes the path problem in Windows - the problem was originally raised here https://github.com/guardian/sbt-jasmine-example/issues/1.
